### PR TITLE
Omit redundant account name in parentheses when renaming

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,11 +172,25 @@ async function setMemberName(msg, userId, gw2username) {
                 var members = msg.channel.guild.members
                 members.find(member => {
                     if (member.id === userId) {
-                        var nickname = (member.user.username ? member.user.username : '')
+                        var nickname = (member.user.nick ? member.user.nick : member.user.username)
+
+                        var partInParentheses = gw2username;
+
+                        // If the player's Discord name is the same as the account name, we omit it in the parentheses.
+                        var split = gw2username.split(".")
+                        if (split.length == 2) {
+                            var gw2accountName = split[0]
+                            var gw2accountNumber = split[1]
+
+                            if (nickname == gw2accountName) {
+                                partInParentheses = "." + gw2accountNumber;
+                            }
+                        }
+
                         var newnick = (
-                            ((nickname.length + gw2username.length) > 29) ?
-                            nickname.substring(0, 32 - (gw2username.length + 4)) + '… (' + gw2username + ')' :
-                            nickname.substring(0, 32 - (gw2username.length + 3)) + ' (' + gw2username + ')'
+                            ((nickname.length + partInParentheses.length) > 29) ?
+                            nickname.substring(0, 32 - (partInParentheses.length + 4)) + '… (' + partInParentheses + ')' :
+                            nickname.substring(0, 32 - (partInParentheses.length + 3)) + ' (' + partInParentheses + ')'
                         )
                         member.edit({
                             nick: newnick


### PR DESCRIPTION
A simple change to avoid being renamed to `Capybara (Capybara.1234)`. Instead, a name in form of `Capybara (.1234)` is used.

Also checks the nickname instead of the username. The old check was not doing anything if the documentation of Eris can be trusted (the username should never be falsy unless it's empty - which would be the result anyway).